### PR TITLE
Add a type for the `channel` argument to service stub constructor

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+betterproto/templates/template.py linguist-generated=false

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ betterproto/tests/*.py
 dist
 **/*.egg-info
 output
+.idea

--- a/betterproto/templates/template.py
+++ b/betterproto/templates/template.py
@@ -13,6 +13,10 @@ from typing import {% for i in description.typing_imports %}{{ i }}{% if not loo
 
 import betterproto
 
+{% if description.services %}
+import grpc
+{% endif %}
+
 {% for i in description.imports %}
 {{ i }}
 {% endfor %}
@@ -60,7 +64,7 @@ class {{ service.py_name }}Stub(object):
 {{ service.comment }}
 
     {% endif %}
-    def __init__(self, channel):
+    def __init__(self, channel: grpc.Channel):
         {% for method in service.methods %}
             {% if method.comment %}
 {{ method.comment }}


### PR DESCRIPTION
This ensures that the generated file is strongly/strictly mypy typed.